### PR TITLE
Fix deployment issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,18 +2,17 @@ name: Deploy
 
 on:
   workflow_call:
-  push:
-    tags: ['[0-9].[0-9].[0-9]']
   release:
     types: [created]
 
 env:
-  APP_NAME: Creasi Skeleton
+  APP_NAME: ${{ vars.APP_NAME }}
   APP_ENV: staging
-  APP_LOCALE: id
-  APP_URL: https://skeleton.creasi.dev
   APP_KEY: ${{ secrets.APP_KEY }}
+  APP_LOCALE: id
   VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  # GIT_COMMIT_SHA: ${{ github.sha }}
+  # GIT_BRANCH: ${{ github.ref }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,7 +25,10 @@ jobs:
 
     environment:
       name: staging
-      url: ${{ env.APP_URL }}
+      url: ${{ vars.APP_URL }}
+
+    env:
+      APP_URL: ${{ vars.APP_URL }}
 
     strategy:
       fail-fast: false
@@ -38,6 +40,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Prepare Environments
+        run: |
+          echo "GIT_BRANCH=$(echo ${GIT_BRANCH##*/} | tr / -)" >> $GITHUB_ENV
+          [[ ! -d $HOME/.ssh ]] && mkdir $HOME/.ssh
+          echo "${{ secrets.STAGING_SERVER_RSAKEY }}" >> $HOME/.ssh/id_rsa
+          echo "${{ secrets.STAGING_SERVER_SSH_CONFIG }}" >> $HOME/.ssh/config
+          chmod 600 $HOME/.ssh/* && ls -al $HOME/.ssh/
+          git config user.name "Creasi.HQ" && git config user.email "dev@creasi.co"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -66,14 +77,6 @@ jobs:
           command: |
             composer config -g github-oauth.github.com ${{ secrets.PAT }}
             composer install --prefer-dist --no-interaction --no-progress
-
-      - name: Prepare
-        run: |
-          [[ ! -d $HOME/.ssh ]] && mkdir $HOME/.ssh
-          echo "${{ secrets.STAGING_SERVER_RSAKEY }}" >> $HOME/.ssh/id_rsa
-          echo "${{ secrets.STAGING_SERVER_SSH_CONFIG }}" >> $HOME/.ssh/config
-          chmod 600 $HOME/.ssh/* && ls -al $HOME/.ssh/
-          git config user.name "Creasi.HQ" && git config user.email "dev@creasi.co"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,7 @@ jobs:
           command: |
             composer config -g github-oauth.github.com ${{ secrets.PAT }}
             composer install --prefer-dist --no-interaction --no-progress
+            composer ziggy:generate
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
-name: Release
+name: Deploy
 
 on:
+  workflow_call:
   push:
     tags: ['[0-9].[0-9].[0-9]']
   release:
@@ -8,22 +9,11 @@ on:
 
 env:
   APP_NAME: Creasi Skeleton
-  APP_ENV: testing
-  APP_URL: http://127.0.0.1:8000
+  APP_ENV: staging
+  APP_LOCALE: id
+  APP_URL: https://skeleton.creasi.dev
   APP_KEY: ${{ secrets.APP_KEY }}
-  # AWS_ENDPOINT: 'https://is3.cloudhost.id'
-  # AWS_DEFAULT_REGION: 'ap-southeast-3'
-  # AWS_BUCKET: creasi-staging
-  DB_DATABASE: creasico
-  DB_USERNAME: creasico
-  DB_PASSWORD: secret
-  MAIL_FROM_ADDRESS: devtest@creasi.dev
-  SENTRY_LARAVEL_DSN: ${{ secrets.SENTRY_DSN }}
-  SENTRY_TRACE_QUEUE_ENABLED: true
-  SENTRY_TRACES_SAMPLE_RATE: 1.0
   VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-  VITE_SENTRY_TRACE_QUEUE_ENABLED: true
-  VITE_SENTRY_TRACES_SAMPLE_RATE: 1.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,13 +26,46 @@ jobs:
 
     environment:
       name: staging
-      url: https://skeleton.creasi.dev
+      url: ${{ env.APP_URL }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1']
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl, intl, libxml, mbstring, pcntl, ssh2, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php }}-composer-
+          restore-keys: ${{ runner.os }}-${{ matrix.php }}-composer-
+
+      - name: Install PHP dependencies
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: |
+            composer config -g github-oauth.github.com ${{ secrets.PAT }}
+            composer install --prefer-dist --no-interaction --no-progress
 
       - name: Prepare
         run: |
@@ -61,30 +84,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: pnpm
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Install Node.JS dependencies
         run: pnpm install
 
       - name: Build frontend assets
         run: pnpm build
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-          extensions: curl, intl, libxml, mbstring, pcntl, ssh2, zip
-          tools: composer:v2
-          coverage: none
-
-      - name: Install PHP dependencies
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: |
-            composer config -g github-oauth.github.com ${{ secrets.PAT }}
-            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Deploy repo
         uses: nick-invision/retry@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,11 @@ on:
     # paths: ['.github/**.yml', '**.php', '**.js', '**.ts', '**.vue']
 
 env:
-  APP_NAME: Creasi Skeleton
+  APP_NAME: ${{ vars.APP_NAME }}
   APP_ENV: testing
   APP_URL: http://127.0.0.1:8000
   APP_KEY: ${{ secrets.APP_KEY }}
+  APP_LOCALE: id
   # AWS_ENDPOINT: 'https://is3.cloudhost.id'
   # AWS_DEFAULT_REGION: 'ap-southeast-3'
   # AWS_BUCKET: creasi-staging
@@ -26,10 +27,6 @@ env:
   DB_PASSWORD: secret
   MAIL_FROM_ADDRESS: devtest@creasi.dev
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -54,7 +51,6 @@ jobs:
       - name: Get Composer cache directory
         id: composer-cache
         run: |
-          echo "GIT_BRANCH=$(echo ${GIT_BRANCH##*/} | tr / -)" >> $GITHUB_ENV
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
@@ -144,7 +140,6 @@ jobs:
       - name: Get Composer cache directory
         id: composer-cache
         run: |
-          echo "GIT_BRANCH=$(echo ${GIT_BRANCH##*/} | tr / -)" >> $GITHUB_ENV
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
@@ -223,7 +218,6 @@ jobs:
       - name: Get Composer cache directory
         id: composer-cache
         run: |
-          echo "GIT_BRANCH=$(echo ${GIT_BRANCH##*/} | tr / -)" >> $GITHUB_ENV
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: pnpm
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -291,70 +291,7 @@ jobs:
           ./cc-test-reporter sum-coverage -o - tests/reports/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
 
   deploy:
-    runs-on: ubuntu-latest
-    name: Deploy
+    name: Trigger Deploy
     needs: e2e
-    if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
-
-    environment:
-      name: staging
-      url: https://skeleton.creasi.dev
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-          extensions: curl, intl, libxml, mbstring, pcntl, ssh2, zip
-          ini-values: error_reporting=E_ALL
-          tools: composer:v2
-          coverage: none
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: |
-          echo "GIT_BRANCH=$(echo ${GIT_BRANCH##*/} | tr / -)" >> $GITHUB_ENV
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Prepare
-        run: |
-          [[ ! -d $HOME/.ssh ]] && mkdir $HOME/.ssh
-          echo "${{ secrets.STAGING_SERVER_RSAKEY }}" >> $HOME/.ssh/id_rsa
-          echo "${{ secrets.STAGING_SERVER_SSH_CONFIG }}" >> $HOME/.ssh/config
-          chmod 600 $HOME/.ssh/* && ls -al $HOME/.ssh/
-          git config user.name "Creasi.HQ" && git config user.email "dev@creasi.co"
-
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: composer install --prefer-dist --no-interaction --no-progress
-
-      - name: Download assets
-        id: download
-        uses: actions/download-artifact@v3
-        with:
-          name: public
-          path: public/build
-
-      - name: Deploy repo
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: |
-            composer dep deploy:unlock
-            composer dep deploy
+    uses: ./.github/workflows/deploy.yml
+    # if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}


### PR DESCRIPTION
Diketahui adanya issue pada project yang ter-deploy ke server. Dimana end-point URL di frontend masih menggunakan local endpoint, hal tersebut kemungkinan besar dikarenakan konfigurasi berikut

https://github.com/creasico/laravel-project/blob/f7de4dc7e21a8b627db2b3f6f64c29baa1506559/.github/workflows/main.yml#L14-L18

Yang menjadikan setiap form request tidak mengarahkan ke url yang semestinya.

<img width="1435" alt="Screenshot 2023-07-09 at 21 51 08" src="https://github.com/creasico/laravel-project/assets/508665/f5cae2c3-af36-49f5-91b9-451a94d5d8ba">

Selain itu, saat ini di project ini ada 2 workflow yaitu `main` dan `build-deploy` dimana memiliki job yang sama, yaitu deploy. Bedanya di workflow `main` deployment khusus untuk branch `main` saja, dan belum mendukung untuk deployment di branch lain ataupun pull request. Sedangkan workflow `build-deploy` hanya untuk deployment berbasis tags, yang mana cukup jarang atau jarang sekali digunakan, setidaknya saat ini.

Masalahnya adalah ketika ada perubahan konfigurasi di workflow `main`, tentu kita juga harus mengubah konfigurasi di `build-deploy` juga. Yangmana hal tersebut rawan sekali lupa (termasuk saya).

Dalam PR ini saya coba untuk merubah workflow deployment nantinya hanya ada 1 yaitu `deploy` dengan hanya di-trigger melalui tag (seperti sebelumnya) dan juga di-trigger dari workflow `main` setelah `e2e` job selesai.

see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_call