### PR TITLE
Fix release workflows

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,6 @@ changelog:
       - dependabot[bot]
 
   categories:
-    - title: What's Changed
+    - title: Contributions
       labels:
         - '*'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ run-name: >-
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        append_body: true
+        discussion_category_name: true
         body_path: PUBLISH.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   publish:


### PR DESCRIPTION
Dari #55 & #36 kita belajar bahwa file `.github/release.yml` hanya sebagai konfigurasi untuk secara **otomatis meng-generate release note** ketika kita **(secara manual) membuat release**. Dalam hal ini antara release note dan release adalah 2 hal yang berbeda.

Untungnya sejak versi [v0.1.14](https://github.com/softprops/action-gh-release/releases/tag/v0.1.14) action tersebut sudah mendukung kombinasi generate release note. Dengan cukup menambahkan field `generate_release_notes`

Disamping itu ketika kita push tag, event `release.created` akan ter-trigger makanya workflow `deploy` akan jalan, dan malah workflow `release` gak jalan karna dia menunggu `release.published`. Untuk itu di PR ini saya balik trigger nya.

```mermaid
flowchart LR
    user("Engineer
    Create a tag")
    ciRelease("CI Release
    Generate and Publish Release")
    ciDeploy("CI Deploy
    Deploy to server")

    user --push--> ciRelease
    ciRelease --published-->ciDeploy
```