### PR TITLE
Migrate from `husky` to `simple-git-hooks`, see #31

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build": "vite build",
     "dev": "vite",
     "lint": "eslint --ext .ts,.json,.vue resources",
-    "prepare": "husky install scripts/husky",
     "release": "standard-version -s"
   },
   "dependencies": {
@@ -35,10 +34,10 @@
     "@vueuse/core": "^10.5.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.51.0",
-    "husky": "^8.0.3",
     "laravel-vite-plugin": "^0.8.1",
     "lint-staged": "^15.0.2",
     "naive-ui": "^2.35.0",
+    "simple-git-hooks": "^2.9.0",
     "standard-version": "^9.5.0",
     "unplugin-auto-import": "^0.16.6",
     "unplugin-vue-components": "^0.25.2",
@@ -62,6 +61,10 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
+  },
+  "simple-git-hooks": {
+    "commit-msg": "pnpm exec commitlint --edit $1",
+    "pre-commit": "pnpm exec lint-staged --allow-empty"
   },
   "lint-staged": {
     "*.{json,js,ts,vue}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,6 @@ devDependencies:
   eslint:
     specifier: ^8.51.0
     version: 8.52.0
-  husky:
-    specifier: ^8.0.3
-    version: 8.0.3
   laravel-vite-plugin:
     specifier: ^0.8.1
     version: 0.8.1(vite@4.5.0)
@@ -85,6 +82,9 @@ devDependencies:
   naive-ui:
     specifier: ^2.35.0
     version: 2.35.0(vue@3.3.7)
+  simple-git-hooks:
+    specifier: ^2.9.0
+    version: 2.9.0
   standard-version:
     specifier: ^9.5.0
     version: 9.5.0
@@ -4581,12 +4581,6 @@ packages:
     engines: {node: '>=16.17.0'}
     dev: true
 
-  /husky@8.0.3:
-    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
     dev: true
@@ -6170,6 +6164,12 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+    dev: true
+
+  /simple-git-hooks@2.9.0:
+    resolution: {integrity: sha512-waSQ5paUQtyGC0ZxlHmcMmD9I1rRXauikBwX31bX58l5vTOhCEcBC5Bi+ZDkPXTjDnZAF8TbCqKBY+9+sVPScw==}
+    hasBin: true
+    requiresBuild: true
     dev: true
 
   /slash@3.0.0:

--- a/scripts/.gitattributes
+++ b/scripts/.gitattributes
@@ -1,3 +1,2 @@
-/husky             export-ignore
 /deploy.php        export-ignore
 /post-create.sh    export-ignore

--- a/scripts/husky/commit-msg
+++ b/scripts/husky/commit-msg
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-. "$(dirname "$0")/_/husky.sh"
-
-./node_modules/.bin/commitlint --edit $1

--- a/scripts/husky/pre-commit
+++ b/scripts/husky/pre-commit
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-. "$(dirname "$0")/_/husky.sh"
-
-./node_modules/.bin/lint-staged --allow-empty


### PR DESCRIPTION
Ada beberapa hal yang perlu dilakukan untuk migrasi dari `husky` ke `simple-git-hooks` ini, yaitu :

```
git config core.hooksPath .git/hooks
pnpm exec simple-git-hooks
```

> **Note**
> Command diatas hanya berlaku untuk kalian yang sudah clone dan menjalankan repo ini di local saja.

Selengkapnya bisa baca [dokumentasi](https://github.com/toplenboren/simple-git-hooks#when-migrating-from-husky-git-hooks-are-not-running) terkait

closes #31