### PR TITLE
feat: auto-deploy preview untuk pull request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ on:
   workflow_run:
     workflows: [Code Quality]
     types: [completed]
-    branches: [main, feat/*]
+    branches: [main, feat/**]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ run-name: >-
   deploy ${{ github.ref_name }} to ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'staging' }}
 
 on:
+  pull_request:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -11,6 +13,10 @@ on:
         description: Deployment target
         required: true
         type: environment
+      reset:
+        description: Reset database
+        default: false
+        type: boolean
   workflow_run:
     workflows: [Code Quality]
     types: [completed]
@@ -76,8 +82,13 @@ jobs:
 
       - name: Deploy
         uses: deployphp/action@master
+        env:
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_RESET: ${{ github.event_name == 'workflow_dispatch' && inputs.reset || false }}
+          DEPLOY_ARGS: --branch ${{ needs.prepare.outputs.target-branch }} --${{ env.DB_RESET == 'true' && 'no-reset' || 'no-reset' }}
         with:
           private-key: ${{ secrets.DEPLOY_SSH_RSAKEY }}
           ssh-config: ${{ secrets.DEPLOY_SSH_CONFIG }}
           verbosity: ''
-          dep: deploy -f scripts/deploy.php env=${{ env.APP_ENV }} --branch ${{ github.ref_name }}
+          dep: deploy -f scripts/deploy.php env=staging ${{ env.DEPLOY_ARGS }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ on:
   workflow_run:
     workflows: [Code Quality]
     types: [completed]
-    branches: [main, feat/**]
+    branches: [main, 'feat/**']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ run-name: >-
   deploy ${{ github.ref_name }} to ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'staging' }}
 
 on:
-  pull_request:
-    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -20,7 +18,6 @@ on:
   workflow_run:
     workflows: [Code Quality]
     types: [completed]
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ on:
   workflow_run:
     workflows: [Code Quality]
     types: [completed]
+    branches: [main, feat/*]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,24 @@ env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
 jobs:
+  labels:
+    name: Labels
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Labeler
+        uses: actions/labeler@v5
+        with:
+          dot: true
+
   prepare:
     name: Prepare
     # uses: creasico/laravel-project/.github/workflows/prepare.yml@main

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -21,24 +21,6 @@ on:
         value: ${{ jobs.build.outputs.target-url }}
 
 jobs:
-  labels:
-    name: Labels
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Labeler
-        uses: actions/labeler@v5
-        with:
-          dot: true
-
   build:
     runs-on: ubuntu-latest
     name: Build for `${{ inputs.target }}`

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -11,12 +11,14 @@ on:
     outputs:
       composer-cache:
         value: ${{ jobs.build.outputs.composer-cache }}
+      should-reports:
+        value: ${{ jobs.build.outputs.should-reports }}
+      target-branch:
+        value: ${{ jobs.build.outputs.target-branch }}
       target-env:
         value: ${{ jobs.build.outputs.target-env }}
       target-url:
         value: ${{ jobs.build.outputs.target-url }}
-      should-reports:
-        value: ${{ jobs.build.outputs.should-reports }}
 
 jobs:
   labels:
@@ -41,13 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Build for `${{ inputs.target }}`
     outputs:
-      target-env: ${{ inputs.target }}
-      target-url: ${{ env.APP_URL }}
       composer-cache: ${{ steps.environments.outputs.composer-cache }}
       should-reports: ${{ steps.environments.outputs.should-reports }}
-
-    environment:
-      name: ${{ inputs.target }}
+      target-branch: ${{ steps.environments.outputs.target-branch }}
+      target-env: ${{ env.APP_ENV }}
+      target-url: ${{ env.APP_URL }}
 
     env:
       APP_ENV: ${{ inputs.target }}
@@ -85,6 +85,7 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
           git config user.name "Creasi.HQ" && git config user.email "developers@creasi.co"
+          echo "target-branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
           echo "composer-cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           echo "should-reports=$([[ -n \"$CC_TEST_REPORTER_ID\" ]] && echo '1')" >> $GITHUB_OUTPUT
 
@@ -98,6 +99,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --prefer-dist --no-interaction --no-progress --ansi
+          composer dep deploy:info -- --branch ${{ steps.environments.outputs.target-branch }}
           composer ziggy:generate
           php artisan vendor:publish --tag creasi-assets --ansi
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,9 +15,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment('local')) {
-            $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
-            // $this->app->register(TelescopeServiceProvider::class);
+        if (app()->environment('local') && \class_exists('\Laravel\Telescope\TelescopeServiceProvider')) {
+            app()->register(\Laravel\Telescope\TelescopeServiceProvider::class);
+            // app()->register(TelescopeServiceProvider::class);
         }
         // .
     }

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
       "@php artisan key:generate --ansi"
     ],
     "dep": [
+      "Composer\\Config::disableProcessTimeout",
       "dep --ansi -f scripts/deploy.php"
     ],
     "fix": [

--- a/scripts/deploy.php
+++ b/scripts/deploy.php
@@ -2,6 +2,9 @@
 
 namespace Deployer;
 
+use Illuminate\Support\Env;
+use Symfony\Component\Console\Input\InputOption;
+
 $rootDir = \dirname(__DIR__);
 
 require 'recipe/laravel.php';
@@ -9,12 +12,13 @@ require $rootDir.'/vendor/autoload.php';
 
 // Config
 
-set('repository', 'git@github.com:creasico/laravel-project.git');
-set('keep_releases', 3);
-
 add('shared_files', []);
 add('shared_dirs', ['public/build', 'public/vendor']);
-add('writable_dirs', ['storage']);
+add('writable_dirs', []);
+
+set('keep_releases', 3);
+
+option('reset', null, InputOption::VALUE_NEGATABLE, 'Reset database', false);
 
 // Hosts
 
@@ -24,18 +28,118 @@ host('skeleton.creasi.dev')
     ->setDeployPath('/var/www/skeleton')
     ->setLabels(['env' => 'staging']);
 
+// Hooks
+
+after('deploy:failed', 'deploy:unlock');
+after('deploy:update_code', 'deploy:environment');
+
 // Tasks
+
+task('deploy:info', function () {
+    set('repository', $repository = runLocally('git remote get-url origin'));
+    set('pull_request', $pullRequest = null);
+    set('original_deploy_path', $deployPath = get('deploy_path'));
+
+    $env = get('labels')['env'] ?? null;
+    $host = currentHost();
+    $masterData = "storage/app/master-data.{$env}.xlsx";
+    $appUrl = Env::get('APP_URL');
+    $onGitHub = Env::get('GITHUB_ENV');
+
+    set('master_data', \file_exists($masterData) ? $masterData : 'storage/app/master-data.xlsx');
+
+    if (! $appUrl || \str_contains($appUrl, 'localhost')) {
+        $appUrl = 'https://'.$host->getAlias();
+    }
+
+    if ($ghRef = Env::get('GITHUB_REF')) {
+        [$_, $ref, $name] = explode('/', $ghRef);
+        if ($ref === 'pull' && \is_numeric($name)) {
+            $pullRequest = $name;
+        }
+    }
+
+    $info = ['deploying <fg=magenta;options=bold>{{target}}</>'];
+
+    if ($pullRequest !== null) {
+        set('pull_request', (int) $pullRequest);
+        set('deploy_path', $deployPath.'-'.$pullRequest);
+
+        if (! \str_contains($appUrl, $pullRequest)) {
+            $subdomain = \basename($deployPath);
+            $appUrl = \str_replace($subdomain, $subdomain.'-'.$pullRequest, $appUrl);
+        }
+
+        $onGitHub && runLocally('echo "APP_ENV=preview-{{pull_request}}" >> $GITHUB_ENV');
+
+        $info[] = 'from PR <fg=magenta;options=bold>#{{pull_request}}</>';
+    }
+
+    $onGitHub && runLocally('echo "APP_URL='.$appUrl.'" >> $GITHUB_ENV');
+    $info[] = 'to <fg=magenta;options=bold>'.$appUrl.'</>';
+
+    info(\implode(' ', $info));
+    info('repository: <fg=magenta;options=bold>'.$repository.'</>');
+})->desc('Check repository');
+
+task('deploy:environment', function () {
+    $releasesList = get('releases_list');
+    $isPullRequest = get('pull_request') !== null;
+    $isInitialDeploy = ((int) last($releasesList)) === \count($releasesList);
+
+    if (! ($isInitialDeploy || $isPullRequest) || test("[ -s {{deploy_path}}/shared/.env ]")) {
+        info("Your deployment already configured! Skipping...");
+        return;
+    }
+
+    $dbName = str(get('deploy_path'))->basename()->slug('_');
+    $envFile = $isPullRequest
+        ? '{{original_deploy_path}}/current/.env'
+        : '{{release_or_current_path}}/.env.example';
+
+    info('initialize environment file');
+    run("cat {$envFile} > {{release_path}}/.env");
+    run("sed -i 's~;APP_ENV=.*~APP_ENV=preview~' {{release_path}}/.env");
+    run("sed -i 's~;DB_DATABASE=.*~DB_DATABASE={$dbName}~' {{release_path}}/.env");
+
+    if ($url = Env::get('APP_URL')) {
+        run("sed -i 's~;APP_URL=.*~APP_URL={$url}~' {{release_path}}/.env");
+    }
+
+    set('dotenv', '{{release_path}}/.env');
+    run('createdb -h "$DB_HOST" -U "$DB_USERNAME" -O "$DB_USERNAME" '.$dbName, env: [
+        'DB_USERNAME' => Env::get('DB_USERNAME'),
+        'PGPASSWORD' => Env::get('DB_PASSWORD'),
+    ]);
+
+    info('database <fg=magenta;options=bold>'.$dbName.'</> created');
+})->desc('Setup deployment environment');
+
+task('deploy:database', function () {
+    if ($isInitialDeploy = (get('dotenv') !== false)) {
+        invoke('artisan:key:generate');
+    }
+
+    if (! input()->getOption('reset')) {
+        invoke('artisan:migrate');
+
+        if ($isInitialDeploy) {
+            invoke('artisan:db:seed');
+        }
+
+        return;
+    }
+
+    invoke('artisan:down');
+    invoke('artisan:migrate:fresh');
+    invoke('artisan:db:seed');
+    invoke('artisan:up');
+})->desc('Deploy database');
 
 task('deploy:assets', function () {
     $config = ['flags' => '-zrtv'];
-    $env = get('labels')['env'] ?? null;
-    $masterData = "storage/app/master-data.{$env}.xlsx";
 
-    if (! \file_exists($masterData)) {
-        $masterData = 'storage/app/master-data.xlsx';
-    }
-
-    if (\file_exists($masterData)) {
+    if (\file_exists($masterData = get('master_data'))) {
         upload($masterData, '{{release_or_current_path}}/storage/app', $config);
     }
 
@@ -45,19 +149,12 @@ task('deploy:assets', function () {
     ]);
 })->desc('Deploy static assets');
 
-// Hooks
-
-after('deploy:failed', 'deploy:unlock');
-
 task('deploy', [
     'deploy:prepare',
     'deploy:vendors',
     'deploy:assets',
     'artisan:storage:link',
     'artisan:optimize:clear',
-    'artisan:down',
-    'artisan:migrate:fresh',
-    'artisan:db:seed',
-    'artisan:up',
+    'deploy:database',
     'deploy:publish',
 ]);


### PR DESCRIPTION
Seperti kita ketahui, selama ini kita cukup kesulitan untuk dapat me-review setiap pekerjaan yang mana mengharuskan reviewer untuk merge dulu setiap PR sebelum melakukan review. Masalahnya adalah jika ternyata masih ada bug atau PR terebut belum sepenuhnya selesai maka dev harus membuat PR baru lagi untuk memperbaiki issue dari PR sebelumnya yang usdah di merge.

Tentu hal tersebut tidak ideal dimana harusnya setiap PR harus selesai dan sudah memenuhi kriteria terlebih dahulu, dan reviewer harus lah dapat melakukan review sebelum sebelum PR tersebut dapat di merge.

Hal tersebut yang menjadikan kita butuh sebuah mekanisme yang memungkinkan untuk melakukan deployment tersendiri di tiap PR agar dapat melakukan review dan tentunya tidak mengganggu deployment pada branch utama.

Mekanisme seperti ini umum kita jumpai pada layanan populer macam Heroku, Vercel, Netlify, dll namun dengan resource yang kita miliki saat ini "tidak memungkinkan" untuk menggunakan layanan semacam itu. 

> **NOTE**
> Kata "tidak memungkinkan" dalam hal ini adalah saya **TIDAK MAU menggunakan akun PERSONAL** di layanan tersebut termasuk menggunakan akun personal saya sendiri karena Creasi.co bukanlah perorangan. Dan untuk menggunakan akun Organisasi pada layanan tersebut belum memungkinkan

Untuk alasan itulah PR ini dibuat dengan meng-imitasi mekanisme serupa namun dengan stack yang jauh lebih sederhana.

## Stack saat ini

- Semua `staging` deployment ditampung dalam satu server dan direktori yang sama
- Konfigurasi `nginx` sudah dibuat untuk dapat secara otomatis mengakomodir setiap project `laravel` yang di tempatkan di direktori tersebut dan di deploy menggunakan `deployer` atau setidaknya memiliki struktur direktori `public` yang serupa.

## Mekanisme yang diterapkan

- Setiap PR baru dengan kritera nama branch tertentu akan secara otomatis di-deploy ke server
- Lokasi deployment berada pada direktori yang sama dengan lokasi deployment branch `main` dengan tambahan nomor PR, misal branch `main` berlokasi di `/var/www/skeleton` maka PR nomor 97 akan di berlokasi di `/var/www/skeleton-97`
- Dengan lokasi tersebut maka PR 97 ini harusnya dapat diakses dengan url `http://skeleton-97.creasi.dev`
- Pada saat PR pertama kali di-deploy harus dapat membuat database baru dengan kredensial yang sama dengan branch `main` namun dengan nama database menyesuaikan dengan project dan nomor PR
- PR dapat di deploy dan di review tanpa harus lolos pengujian baik unit maupun end-to-end.
- Deployment harus dapat dilakukan oleh dev maupun non-dev dan secara manual maupun otomatis via CI/CD

## Environment variables & secrets

Untuk project baru yang dibuat menggunakan template project ini, berikut beberapa environment variable dan secret yang dibutuhkan agar mekanisme deployment diatas dapat berjalan sebagaimana mestinya :

### Variables

- [Repository Variables](https://github.com/creasico/laravel-project/settings/variables/actions)
  - `APP_NAME` : Nama project
  - `SENTRY_PROJECT` : Nama project di sentry (cek Project Settings di Sentry)
- [Environment Variables](https://github.com/creasico/laravel-project/settings/environments)
  - `APP_ENV` : Nama untuk spesifik environment
  - `APP_URL` : URL end-point untuk masing-masing environment

> By default `APP_ENV` untuk branch `main` adalah `staging` dan untuk PR adalah `preview`

### Secrets

- [Repository Secrets](https://github.com/creasico/laravel-project/settings/secrets/actions)
  - `DB_PASSWORD`
  - `DB_USERNAME`
  - `SENTRY_DSN`

> **NOTE**
> Topik environment ini dapat dibaca lebih lanjut [disini](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)

## Panduan untuk Reviewer

ℹ️ Kriteria auto-deploy PR saat ini dibatasi hanya berlaku untuk branch dengan pola nama `feat/**` dan `main`

- Ketika PR telah di deploy, reviewer dapat meng-akses dengan meng-klik tombol <kbd>View deployment</kbd> pada time-line item di PR tersebut

  ![SCR-20240301-eqdq-2](https://github.com/creasico/laravel-project/assets/508665/574b7e06-b137-44cb-a682-634e9ec55392)

- Menual deployment dapat dilakukan dengan mengakses menu berikut, sesuaikan branch dan target deployment yang dibutuhkan dan klik <kbd>Run workflow</kbd>

  ![SCR-20240301-etbq-2](https://github.com/creasico/laravel-project/assets/508665/f22c5ca7-d1e3-4645-b031-6546f4e1036e)

  Setelah deployment selesai, klik workflow tersebut untuk mendapatkan URL dari deployment teresbut.

  ![SCR-20240301-extc-2](https://github.com/creasico/laravel-project/assets/508665/630ad02c-22e7-43f4-94da-ef1bfb455965)

> Setelah PR ini di-merge akan ada opsi baru pada manual deployment untuk dapat melakukan reset database pada saat deployment.

## Catatan untuk dev

Saat ini belum ada implementasi auto-destroy deployment ketika PR di-merge, saya butuh feedback dan liat seberapa positif inpact dari implementasi saat ini terlebih dahulu. Auto-destroy akan saya implementasikan lain waktu, atau silakan jika ada yang mau kontribusi.

Jadi direktory deployment dan database preview untuk PR yang sudah di merge bisa dihapus secara manual.

### Reset database saat deploy

Tambahkan flag `--reset` saat melakukan deployment, contoh : 

```sh
composer dep deploy -- --reset
```